### PR TITLE
Fix `JSONObject["text"] not a string` error

### DIFF
--- a/src/backup/data/Message.java
+++ b/src/backup/data/Message.java
@@ -44,15 +44,15 @@ public class Message {
 	 * @param user Token user
 	 */
 	public Message(JSONObject message, UsersList users, User user) {
-		if(message.has("user")) {
+		if(message.has("user") && !message.opt("user").equals(null)) {
 			String userId = message.getString("user");
 			this.user = userId.equals(user.getId()) ? user : users.getUser(userId);
 		} else
 			this.user = null;
-		this.text = message.has("text") ? message.getString("text"): null;
-		this.subtype = message.has("subtype") ? MessageSubtypes.getSubtype(message.getString("subtype")): null;
-		this.hidden = message.has("hidden") ? message.getBoolean("hidden") : false;
-		this.subMessage = message.has("message") ? new Message(message.getJSONObject("message"), users, user) : null;
+		this.text = message.has("text") && !message.opt("text").equals(null) ? message.getString("text"): null;
+		this.subtype = message.has("subtype") && !message.opt("subtype").equals(null) ? MessageSubtypes.getSubtype(message.getString("subtype")): null;
+		this.hidden = message.has("hidden") && !message.opt("hidden").equals(null) ? message.getBoolean("hidden") : false;
+		this.subMessage = message.has("message") && !message.opt("message").equals(null) ? new Message(message.getJSONObject("message"), users, user) : null;
 	}
 	
 	public boolean isHidden() {


### PR DESCRIPTION
I ran into a bug where the program would crash on certain messages that don't have text associated with them. The JSON would contain `{"text": null}`, but `message.has("text")` would still return `true`, as the value would be a `JSONObject.NULL` object. Therefore I added another check for that. I didn't just add this check for `text`, but for all keys in this file, to harden it a bit better than before.